### PR TITLE
INF-1217 assign default owning team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @payground-inc/default-owners


### PR DESCRIPTION
## Summary
Assign default owner team as default owner if no override is provided on the repo level.

## Issue Link(s)
- INF-1217

## Changes Made

## Impact
N/A


## Checklist
- [ ] Code follows the project's coding standards
- [ ] Unit tests covering the new feature have been added
- [ ] All existing tests are updated and passing.
- [ ] Documentation is updated if needed.
- [ ] Linked JIRA issue key.


## Additional Notes
Any additional information or context relevant to this PR.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Assign the default owning team by adding `@payground-inc/default-owners` to the CODEOWNERS file.

### Why are these changes being made?

This change ensures that the team `@payground-inc/default-owners` is automatically assigned as code owners for all files, which facilitates code ownership and streamlines the review process by ensuring that pull requests are directed to the appropriate team for review.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->